### PR TITLE
Allow to hide the context menuitems via a preference

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -1,6 +1,6 @@
 [
-		{"caption":"-"},
-    { "command": "previous_edit", "caption": "Back" },
-    { "command": "next_edit", "caption": "Forward" },
+    {"caption":"-"},
+    { "command": "previous_edit", "caption": "Back", "args":{"where":"view_context_menu"}},
+    { "command": "next_edit", "caption": "Forward", "args":{"where":"view_context_menu"}},
     {"caption":"-"}
 ]

--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -1,4 +1,6 @@
 [
+		{"caption":"-"},
     { "command": "previous_edit", "caption": "Back" },
-    { "command": "next_edit", "caption": "Forward" }
+    { "command": "next_edit", "caption": "Forward" },
+    {"caption":"-"}
 ]

--- a/Edit History.py
+++ b/Edit History.py
@@ -14,7 +14,8 @@ settings = sublime.load_settings('Edit History.sublime-settings')
 
 class Pref:
     def load(self):
-        Pref.line_proximity_thresh = settings.get('line_proximity_thresh', 5)
+        Pref.line_proximity_thresh        = settings.get('line_proximity_thresh', 5)
+        Pref.visible_on_view_context_menu = settings.get('visible_on_view_context_menu', True)
 Pref = Pref()
 Pref.load()
 settings.add_on_change('reload', lambda: Pref.load())
@@ -162,18 +163,30 @@ class ClearEditsCommand(sublime_plugin.TextCommand):
 class PreviousEditCommand(sublime_plugin.TextCommand):
     """Moves the cursor to the previous edit in the current file"""
 
-    def run(self, edit):
+    def run(self, edit, where = 'unknow'):
         history = get_history(self.view)
 
         if not history.back():
             self.view.set_status(HISTORY_KEY, "No previous edit history")
 
+    def is_visible(self, where = 'unknow'):
+        if where == 'view_context_menu' and not Pref.visible_on_view_context_menu:
+            return False
+        else:
+            return True
+
 
 class NextEditCommand(sublime_plugin.TextCommand):
     """Moves the cursor to the next edit in the current file"""
 
-    def run(self, edit):
+    def run(self, edit, where = 'unknow'):
         history = get_history(self.view)
 
         if not history.forward():
             self.view.set_status(HISTORY_KEY, "No next edit history")
+
+    def is_visible(self, where = 'unknow'):
+        if where == 'view_context_menu' and not Pref.visible_on_view_context_menu:
+            return False
+        else:
+            return True

--- a/Edit History.sublime-settings
+++ b/Edit History.sublime-settings
@@ -1,3 +1,4 @@
 {
-	"line_proximity_thresh": 5
+	"line_proximity_thresh": 5,
+	"visible_on_view_context_menu": true
 }


### PR DESCRIPTION
I was going to request you to remove the "Context.sublime-menu" file.

Maybe some people will prefer to have the menu-items there.

The problem with this, is that people that don't use these menuitems, can't remove it because in the next update, the menuitems will reappear.

To allow a customization of this, I added a preference which controls if the menuitems should be shown.

Regards
